### PR TITLE
Implement QUEUES to retrieve all the queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,9 @@ the specified number of jobs are returned from the oldest to the newest
 commands changes behavior and shows the *count* newest jobs, from the newest
 from the oldest.
 
+    QUEUES
+Return all the queue names
+
     ENQUEUE <job-id> ... <job-id>
 Queue jobs if not already queued.
 

--- a/src/disque.c
+++ b/src/disque.c
@@ -139,7 +139,8 @@ struct serverCommand serverCommandTable[] = {
 
     /* Queues */
     {"qlen",qlenCommand,2,"rF",0,NULL,0,0,0,0,0},
-    {"qpeek",qpeekCommand,3,"r",0,NULL,0,0,0,0,0}
+    {"qpeek",qpeekCommand,3,"r",0,NULL,0,0,0,0,0},
+    {"queues",queuesCommand,1,"rF",0,NULL,0,0,0,0,0}
 };
 
 /*============================ Utility functions ============================ */
@@ -1685,6 +1686,14 @@ void timeCommand(client *c) {
     addReplyMultiBulkLen(c,2);
     addReplyBulkLongLong(c,tv.tv_sec);
     addReplyBulkLongLong(c,tv.tv_usec);
+}
+
+void queuesCommand(client *c) {
+    addReplyMultiBulkLen(c, dictSize(server.queues));
+    dictSafeForeach(server.queues,de)
+        queue *q = dictGetVal(de);
+        addReplyBulkCString(c, q->name->ptr);
+    dictEndForeach
 }
 
 void shutdownCommand(client *c) {

--- a/src/disque.h
+++ b/src/disque.h
@@ -862,6 +862,7 @@ void deljobCommand(client *c);
 void bgrewriteaofCommand(client *c);
 void helloCommand(client *c);
 void qpeekCommand(client *c);
+void queuesCommand(client *c);
 
 #if defined(__GNUC__)
 void *calloc(size_t count, size_t size) __attribute__ ((deprecated));

--- a/tests/cluster/tests/03-jobs-queueing.tcl
+++ b/tests/cluster/tests/03-jobs-queueing.tcl
@@ -117,3 +117,14 @@ test "Single node jobs are correctly ordered in a FIFO fashion" {
         assert {$body == $j}
     }
 }
+
+test "Job queue names can be retrieved using the QUEUE command" {
+    set initial [D 0 queues]
+
+    for {set j 0} {$j < 3} {incr j} {
+        D 0 addjob "queue$j" body 0
+    }
+
+    set resulting [D 0 queues]
+    assert {[lsort "$resulting"] == [lsort "queue0 queue1 queue2 $initial"]}
+}


### PR DESCRIPTION
This commit implements a `QUEUES` method that allows users to retrieve
all the queues from a cluster.

```
127.0.0.1:7711> addjob foo 0 0
DI8c3ab90542c86f6f6fbd7b5f21369de834be3da805a0SQ
127.0.0.1:7711> addjob bar 0 0
DI8c3ab905f003f9d144329c6ed1fc655e027db09905a0SQ
127.0.0.1:7711> addjob baz 0 0
DI8c3ab9057697425d4551c69c00b6888678e3966005a0SQ
127.0.0.1:7711> queues
1) "foo"
2) "baz"
3) "bar"
```

The list of queues is not ordered as we only iterate over the dictionary
that we use to store the queues.
