### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:15.04
+MAINTAINER antirez antirez@gmail.com
+
+# Install tools
+RUN apt-get -y update
+RUN apt-get install -y make
+RUN apt-get install -y gcc
+
+# Add disque
+ADD . /disque
+WORKDIR /disque
+
+# Build project
+RUN make
+
+# Expose port
+EXPOSE 7711
+
+# Run server
+CMD /disque/src/disque-server


### PR DESCRIPTION
Build `disque` from source code in docker container, which makes sure everyone can use it easily and repeatable.

Usage:

```
docker build -t disque .
docker run -d --net=host disque
```
