### PR TITLE
add disque C++ client library

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,10 @@ API on top of Disque:
 
 - [disque-rb](https://github.com/soveran/disque-rb)
 
+*C++*
+
+- [disque C++ client](https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/samples/disque)
+
 Implementation details
 ===
 


### PR DESCRIPTION
I've completed a disque C++ client in https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/samples/disque, which supports connection pool and cluster. This library is based on the acl redis C++ client adopted by redis.io, which is in https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/samples/redis.
