### PR TITLE
QUEUES command.

### DIFF
--- a/src/disque.c
+++ b/src/disque.c
@@ -139,7 +139,8 @@ struct serverCommand serverCommandTable[] = {
 
     /* Queues */
     {"qlen",qlenCommand,2,"rF",0,NULL,0,0,0,0,0},
-    {"qpeek",qpeekCommand,3,"r",0,NULL,0,0,0,0,0}
+    {"qpeek",qpeekCommand,3,"r",0,NULL,0,0,0,0,0},
+    {"queues",queuesCommand,1,"rF",0,NULL,0,0,0,0,0}
 };
 
 /*============================ Utility functions ============================ */

--- a/src/disque.h
+++ b/src/disque.h
@@ -862,6 +862,7 @@ void deljobCommand(client *c);
 void bgrewriteaofCommand(client *c);
 void helloCommand(client *c);
 void qpeekCommand(client *c);
+void queuesCommand(client *c);
 
 #if defined(__GNUC__)
 void *calloc(size_t count, size_t size) __attribute__ ((deprecated));

--- a/src/queue.c
+++ b/src/queue.c
@@ -792,3 +792,22 @@ void qpeekCommand(client *c) {
     }
     setDeferredMultiBulkLength(c,deflen,returned);
 }
+
+/* QUEUES
+ *
+ * Return an array of the names of all registered queues. */
+void queuesCommand(client *c) {
+    dictIterator *di;
+    dictEntry *de;
+    unsigned long numqueues = 0;
+    void *replylen = addDeferredMultiBulkLength(c);
+
+    di = dictGetSafeIterator(server.queues);
+    while((de = dictNext(di)) != NULL) {
+        robj *qname = dictGetKey(de);
+        addReplyBulk(c,qname);
+        numqueues++;
+    }
+    dictReleaseIterator(di);
+    setDeferredMultiBulkLength(c,replylen,numqueues);
+}


### PR DESCRIPTION
Similar to `KEYS`.

I know we have `SCAN` in Redis, but `QUEUES` is super useful for debugging or quick and dirty introspection.

@antirez Let me know if you favor this and then I'll update documentation as part of this PR.
