### PR TITLE
Protential memory leak.

### DIFF
--- a/src/disque.c
+++ b/src/disque.c
@@ -524,6 +524,21 @@ void flushServerData(void) {
         freeJob(job);
     dictEndForeach
 
+    listIter li;
+    listNode *ln;
+    listRewind(server.clients,&li);
+    while((ln = listNext(&li))) {
+        client *c= ln->value;
+        /* As we already unregister and free all the jobs, if a client
+         * is blocked, it must be of the BLOCKED_QUEUES type. We need
+         * to unblock and inform the client before destroy queue. */
+        if (c->flags & DISQUE_BLOCKED) {
+            addReplyError(c, "Queue deleted by the system "
+                    "administrator while blocking on it");
+            unblockClient(c);
+        }
+    }
+
     dictSafeForeach(server.queues,de)
         queue *q = dictGetVal(de);
         serverAssert(queueLength(q) == 0);

--- a/src/queue.c
+++ b/src/queue.c
@@ -102,6 +102,12 @@ int destroyQueue(robj *name) {
     dictDelete(server.queues,name);
     decrRefCount(q->name);
     skiplistFree(q->sl);
+    if (q->needjobs_responders)
+        dictRelease(q->needjobs_responders);
+    if (q->clients) {
+        serverAssert(listLength(q->clients) == 0);
+        listRelease(q->clients);
+    }
     zfree(q);
     return DISQUE_OK;
 }


### PR DESCRIPTION
queue.c/destroyQueue: release needjobs_responders and clients if needed

eg: GCQueue() will leak clients `if (q->clients && listLength(q->clients) == 0)`
