### PR TITLE
job.c/addjobCommand: remove new job from server.awakeme if needed

### DIFF
--- a/src/job.c
+++ b/src/job.c
@@ -1212,6 +1212,11 @@ void addjobCommand(client *c) {
             clusterNode *n = dictGetVal(de);
             clusterSendEnqueue(n,job,job->delay);
         }
+        /* If the new job is already added into server.awakeme list,
+         * we must remove it to avoid visiting freed memory. */
+        if (job->awakeme) {
+            serverAssert(skiplistDelete(server.awakeme,job));
+        }
         /* We don't have to unregister the job since we did not registered
          * it if it's async + extrepl. */
         freeJob(job);


### PR DESCRIPTION
When async && extrepl is TRUE, updateJobAwakeTime(job,0);(line 1195)
may be triggered. But we finally free the new job without remove it
from server.awakeme list.
