### PR TITLE
make sure that a randomKey is returned during a GC cycle to avoid a Segfault

### DIFF
--- a/src/disque.c
+++ b/src/disque.c
@@ -2151,16 +2151,30 @@ int freeMemoryIfNeeded(void) {
          * to free jobs. */
         de = dictGetRandomKey(server.jobs);
         delta = (long long) zmalloc_used_memory();
-        job *job = dictGetKey(de);
-        if (job->state == JOB_STATE_ACKED) {
-            unregisterJob(job);
-            freeJob(job);
-            not_freed = 0;
+        /* If disque starts without any jobs in memory, it could happen, that
+         * dictGetRandomKey returns NULL.
+         */
+        if (de) {
+            job *job = dictGetKey(de);
+            if (job->state == JOB_STATE_ACKED) {
+                unregisterJob(job);
+                freeJob(job);
+                not_freed = 0;
+            } else {
+                not_freed++;
+            }
+            delta -= (long long) zmalloc_used_memory();
+            mem_freed += delta;
         } else {
+            /* The jobs dictionary has no available jobs, so we can stop the
+             * iterations at this point. */
+            if (dictSize(server.jobs) == 0) {
+              latencyEndMonitor(latency);
+              latencyAddSampleIfNeeded("eviction-cycle",latency);
+              return DISQUE_ERR;
+            }
             not_freed++;
         }
-        delta -= (long long) zmalloc_used_memory();
-        mem_freed += delta;
 
         /* If no object was freed in the latest N iterations or we are here
          * for more than 1 or 2 milliseconds, return to the caller with a


### PR DESCRIPTION
A new disque instance without any jobs in memory is running. If we set the max-memory limit using CONFIG SET max-memory to a really low limit causes a gc cycle. The disque instance tries now to free memory using `freeMemoryIfNeeded`. Random keys that can be freed are returned from the dictionary. If the server has no jobs there wont be a random key and NULL is returned. This commit
introduces a check to make sure, that a random key is found.
