### PR TITLE
trigger gc cycles depending on the max memory lvl

### DIFF
--- a/src/disque.c
+++ b/src/disque.c
@@ -2162,6 +2162,19 @@ int freeMemoryIfNeeded(void) {
         delta -= (long long) zmalloc_used_memory();
         mem_freed += delta;
 
+        /* Free idle queues (queues that are empty, have no clients in their
+         * list and are idle for a given time). Another gc cycle is also
+         * triggered in each cron job, if the server reached at least 75% of
+         * its max memory. */
+        de = dictGetRandomKey(server.queues);
+        if (de) {
+            delta = (long long) zmalloc_used_memory();
+            queue* queue = dictGetKey(de);
+            GCQueue(queue);
+            delta -= (long long) zmalloc_used_memory();
+            mem_freed += delta;
+        }
+
         /* If no object was freed in the latest N iterations or we are here
          * for more than 1 or 2 milliseconds, return to the caller with a
          * failure return value. */

--- a/src/queue.c
+++ b/src/queue.c
@@ -209,7 +209,7 @@ unsigned long queueNameLength(robj *qname) {
 /* Remove a queue that was not accessed for enough time, has no clients
  * blocked, has no jobs inside. If the queue is removed DISQUE_OK is
  * returned, otherwise DISQUE_ERR is returned. */
-#define QUEUE_MAX_IDLE_TIME (60*5)
+#define QUEUE_MAX_IDLE_TIME (10*5)
 int GCQueue(queue *q) {
     time_t elapsed = server.unixtime - q->atime;
     if (elapsed < QUEUE_MAX_IDLE_TIME) return DISQUE_ERR;
@@ -224,6 +224,8 @@ int GCQueue(queue *q) {
 void queueCron(void) {
     mstime_t start = mstime();
     long sampled = 0, evicted = 0;
+
+    if (getMemoryWarningLevel() == 0) return;
 
     while (dictSize(server.queues) != 0) {
         dictEntry *de = dictGetRandomKey(server.queues);

--- a/src/queue.h
+++ b/src/queue.h
@@ -84,6 +84,7 @@ unsigned long queueLength(queue *q);
 unsigned long queueNameLength(robj *qname);
 void unblockClientBlockedForJobs(client *c);
 void handleClientsBlockedOnQueues(void);
+int GCQueue(queue *q);
 
 #define NEEDJOBS_CLIENTS_WAITING 0 /* Called because clients are waiting. */
 #define NEEDJOBS_REACHED_ZERO 1    /* Called since we just ran out of jobs. */


### PR DESCRIPTION
Previously the gc was based on the idle time of each queue. The gc behavior happened regardless of the specified max memory and the current memory usage. This new behavior keeps old idle queues in memory, if the max memory limit of at least 75% is not reached.
