### PR TITLE
cluster.c: unblock blocking client when setack

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1352,8 +1352,9 @@ int clusterProcessPacket(clusterLink *link) {
                 /* Reply to the blocked client wating for enough replicate. */
                 client *c = jobGetAssociatedValue(j);
                 setJobAssociatedValue(j,NULL);
-                addReplyError(c, "The job is already acked while blocking "
-                        "for enough replicate");
+                /* Return the jobID to the blocking client as the command is
+                 * successfully executed */
+                addReplyStatusLength(c,j->id,JOB_ID_LEN);
                 unblockClient(c);
             }
             acknowledgeJob(j);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1335,7 +1335,29 @@ int clusterProcessPacket(clusterLink *link) {
             sender->name, hdr->data.jobid.job.id);
 
         job *j = lookupJob(hdr->data.jobid.job.id);
-        if (j) acknowledgeJob(j);
+        if (j) {
+            if (j->state == JOB_STATE_WAIT_REPL) {
+
+                /* Change the job state to active. This is critical to
+                 * avoid the job will be freed by unblockClient(). */
+                j->state = JOB_STATE_ACTIVE;
+                /* If set, cleanup nodes_confirmed to free memory. We'll
+                 * reuse this hash table again for ACKs tracking in order
+                 * to garbage collect the job once processed. */
+                if (j->nodes_confirmed) {
+                    dictRelease(j->nodes_confirmed);
+                    j->nodes_confirmed = NULL;
+                }
+
+                /* Reply to the blocked client wating for enough replicate. */
+                client *c = jobGetAssociatedValue(j);
+                setJobAssociatedValue(j,NULL);
+                addReplyError(c, "The job is already acked while blocking "
+                        "for enough replicate");
+                unblockClient(c);
+            }
+            acknowledgeJob(j);
+        }
         if (j == NULL || dictSize(j->nodes_delivered) <= mayhave) {
             /* If we don't know the job or our set of nodes that may have
              * the job is not larger than the sender, reply with GOTACK. */


### PR DESCRIPTION
when setack msg arriving, we should unblock client who is waiting for enough replicate.
Fixing https://github.com/antirez/disque/issues/73
