### PR TITLE
Update README client libraries with disque_jockey

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ API on top of Disque:
 *Ruby*
 
 - [disque-rb](https://github.com/soveran/disque-rb)
+- [disque_jockey](https://github.com/DevinRiley/disque_jockey)
 
 *.NET*
 


### PR DESCRIPTION
Hey,
Not sure if this is appropriate because disque_jockey isn't striclty a client library -- it provides a framework for writing ruby workers that fetch from Disque, akin to projects like Sidekiq or Resque.  Just thought I'd PR it in case you would like to point people to a project like that.

Cheers
