### PR TITLE
Use Travis CI containerized builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: c
-before_script: sudo apt-get install tcl8.5
+sudo: false
+addons:
+  apt:
+    packages:
+    - tcl8.5
 install: make
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: false
 addons:
   apt:
     packages:
-    - tcl8.5
-install: make
+      - tcl8.5
+cache:
+  directories:
+    - $HOME/.ccache
+install: make CC="ccache $CC"
 script: make test


### PR DESCRIPTION
This updates the Travis CI configuration to leverage the newer docker based builds and adds ccache for an additional speedup.

Builds now take roughly 1m40s instead of 2m30s and also start much faster, so the actual gain is larger.
