### PR TITLE
Add cl-disque to client libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,10 @@ API on top of Disque:
 
 - [disque C++ client](https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/samples/disque)
 
+*Common Lisp*
+
+- [cl-disque](https://github.com/CodyReichert/cl-disque)
+
 *Elixir*
 
 - [exdisque](https://github.com/mosic/exdisque)


### PR DESCRIPTION
Common Lisp client for Disque: https://github.com/CodyReichert/cl-disque
