### PR TITLE
remove call to unknown command

### DIFF
--- a/tests/cluster/tests/includes/init-tests.tcl
+++ b/tests/cluster/tests/includes/init-tests.tcl
@@ -27,7 +27,6 @@ test "Cluster nodes are reachable" {
 
 test "Cluster nodes hard reset" {
     foreach_disque_id id {
-        catch {D $id flushall} ; # May fail for readonly slaves.
         D $id cluster reset hard
         D $id config set cluster-node-timeout 3000
         D $id config rewrite


### PR DESCRIPTION
A call to "debug flushall" is also not needed seeing as
flushServerData is already called in clusterReset.
