### PR TITLE
Don't need safe iterator here

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2361,7 +2361,7 @@ void clusterUpdateReachableNodes(void) {
         zrealloc(server.cluster->reachable_nodes,maxsize);
     server.cluster->reachable_nodes_count = 0;
 
-    di = dictGetSafeIterator(server.cluster->nodes);
+    di = dictGetIterator(server.cluster->nodes);
     while((de = dictNext(di)) != NULL) {
         clusterNode *node = dictGetVal(de);
 


### PR DESCRIPTION
clusterUpdateReachableNodes doesn't change the dict so no need for a safe iterator.

I guess this is a question of correctness versus speed seeing as a safe iterator is faster (no fingerprint).
