### PR TITLE
Updates README.md with django-q python client

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,7 @@ API on top of Disque:
 
 - [disq](https://github.com/ryansb/disq) ([PyPi](https://pypi.python.org/pypi/disq))
 - [pydisque](https://github.com/ybrs/pydisque) ([PyPi](https://pypi.python.org/pypi/pydisque))
+- [django-q](https://github.com/koed00/django-q) ([PyPi](https://pypi.python.org/pypi/django-q))
 
 *Ruby*
 


### PR DESCRIPTION
Adds [django-q](https://github.com/koed00/django-q) to the python clients.

It's not a client perse, but it's the first distributed task queue for Django with a dedicated Disque broker using Redis-py.
