### PR TITLE
Use SOURCE_DATE_EPOCH over unreproducible uname and date calls.

### DIFF
--- a/src/mkreleasehdr.sh
+++ b/src/mkreleasehdr.sh
@@ -2,6 +2,9 @@
 GIT_SHA1=`(git show-ref --head --hash=8 2> /dev/null || echo 00000000) | head -n1`
 GIT_DIRTY=`git diff --no-ext-diff 2> /dev/null | wc -l`
 BUILD_ID=`uname -n`"-"`date +%s`
+if [ -n "$SOURCE_DATE_EPOCH" ]; then
+  BUILD_ID=$(date -u -d "@$SOURCE_DATE_EPOCH" +%s 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" +%s 2>/dev/null || date -u %s)
+fi
 test -f release.h || touch release.h
 (cat release.h | grep SHA1 | grep $GIT_SHA1) && \
 (cat release.h | grep DIRTY | grep $GIT_DIRTY) && exit 0 # Already up-to-date


### PR DESCRIPTION
See https://reproducible-builds.org/specs/source-date-epoch/ for more
details.

Signed-off-by: Chris Lamb chris@chris-lamb.co.uk
