### PR TITLE
Queue randomly

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,18 @@ Disque node.
 
 #### `QLEN <queue-name>`
 
-Return the length of the queue.
+Return the length of the queue in the local node.
+
+#### `GLOBALQLEN <queue-name>`
+
+Return the length of the queue across the cluster.
+
+This is calculated by asking all the nodes their qlen and adding
+all the values together. The values is cached for a second.
+
+The first client to run this command in a node/queue will be blocked
+waiting for the answer. If some node is busy and takes more than .5s
+to reply its items may not be counted.
 
 #### `QSTAT <queue-name>`
 

--- a/disque.conf
+++ b/disque.conf
@@ -432,3 +432,10 @@ hz 10
 # in order to commit the file to the disk more incrementally and avoid
 # big latency spikes.
 aof-rewrite-incremental-fsync yes
+
+# for cases where the queuing of items is more centralized than the
+# dequeuing, we can configure the servers to always queue the jobs
+# in a random node of those it was delivered to, instead of the local,
+# to better distribute the work load.
+queue-randomly no
+

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -138,6 +138,8 @@ void unblockClient(client *c) {
         unblockClientWaitingJobRepl(c);
     } else if (c->btype == BLOCKED_GETJOB) {
         unblockClientBlockedForJobs(c);
+    } else if (c->btype == BLOCKED_GLOBAL_QLEN) {
+        unblockClientBlockedForQLen(c);
     } else {
         serverPanic("Unknown btype in unblockClient().");
     }
@@ -164,6 +166,8 @@ void replyToBlockedClientTimedOut(client *c) {
         return;
     } else if (c->btype == BLOCKED_GETJOB) {
         addReply(c,shared.nullmultibulk);
+    } else if (c->btype == BLOCKED_GLOBAL_QLEN) {
+        /* Do nothing - unblock client will send the best value we got */
     } else {
         serverPanic("Unknown btype in replyToBlockedClientTimedOut().");
     }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -31,6 +31,7 @@
 #include "server.h"
 #include "cluster.h"
 #include "endianconv.h"
+#include "queue.h"
 #include "ack.h"
 
 #include <sys/types.h>

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2118,8 +2118,8 @@ void clusterSendYourJobs(clusterNode *node, job **jobs, uint32_t count) {
     if (payload != buf) zfree(payload);
 }
 
-/* broadcasts a requst for the qlen to the whole cluster.
- * Used by GLOBALQLEN. It replies with the loca queue. */
+/* broadcasts a request for the qlen to the whole cluster.
+ * Used by GLOBALQLEN. It replies with the local queue size. */
 void clusterSendGetQLen(robj *qname, dict *nodes) {
     uint32_t totlen, qnamelen = sdslen(qname->ptr);
     uint32_t alloclen;

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -113,6 +113,8 @@ typedef struct clusterState {
 #define CLUSTERMSG_TYPE_YOURJOBS 13     /* NEEDJOBS reply with jobs. */
 #define CLUSTERMSG_TYPE_WORKING 14      /* Postpone re-queueing & dequeue */
 #define CLUSTERMSG_TYPE_PAUSE 15        /* Change queue paused state. */
+#define CLUSTERMSG_TYPE_GETQLEN 16      /* request the node qlen */
+#define CLUSTERMSG_TYPE_MYQLEN 17       /* reply to node qlen request */
 
 /* Initially we don't know our "name", but we'll find it once we connect
  * to the first node, using the getsockname() function. Then we'll use this
@@ -161,7 +163,10 @@ typedef struct {
  * the PAUSE command to specify the queue to change the paused state. */
 typedef struct {
     uint32_t aux;       /* For NEEDJOB, how many jobs we request.
-                         * FOR PAUSE, the pause flags to set on the queue. */
+                         * FOR PAUSE, the pause flags to set on the queue.
+                         * For MYQLEN, the numer of items in the queue
+                         */
+
     uint32_t qnamelen;  /* Queue name total length. */
     char qname[8];      /* Defined as 8 bytes just for alignment. */
 } clusterMsgDataQueueOp;
@@ -241,5 +246,6 @@ void clusterSendNeedJobs(robj *qname, int numjobs, dict *nodes);
 void clusterSendYourJobs(clusterNode *node, job **jobs, uint32_t count);
 void clusterBroadcastJobIDMessage(dict *nodes, char *id, int type, uint32_t aux, unsigned char flags);
 void clusterBroadcastPause(robj *qname, uint32_t flags);
+void clusterSendGetQLen(robj *qname, dict *nodes);
 
 #endif /* __CLUSTER_H */

--- a/src/config.c
+++ b/src/config.c
@@ -410,6 +410,11 @@ void loadServerConfigFromString(char *config) {
             server.client_obuf_limits[class].hard_limit_bytes = hard;
             server.client_obuf_limits[class].soft_limit_bytes = soft;
             server.client_obuf_limits[class].soft_limit_seconds = soft_seconds;
+        } else if (!strcasecmp(argv[0],"queue-randomly") && argc == 2) {
+            if ((server.queue_randomly = yesnotoi(argv[1])) == -1) {
+                err = "argument must be 'yes' or 'no'"; goto loaderr;
+            }
+
         } else {
             err = "Bad directive or wrong number of arguments"; goto loaderr;
         }

--- a/src/help.h
+++ b/src/help.h
@@ -46,7 +46,7 @@ struct commandHelp {
     { "WORKING", "<jobid>", "Attempt to postpone next delivery of the specified job", 4, "1.0.0" },
     { "NACK", "<jobid> [<jobid> <jobid> ...]", "Negative acknowledge: increment the NACK counter for the job and ask for a next delivery ASAP", 4, "1.0.0" },
     { "QLEN", "<queue>", "Return number of queued jobs in the specified queue in the local node", 3, "1.0.0" },
-    { "GLOBALQLEN", "<queue>", "Return number of queued jobs in the specified queue across the cluster - it's cached for a minute", 3, "1.0.0" },
+    { "GLOBALQLEN", "<queue>", "Return number of queued jobs in the specified queue across the cluster - it's cached for a second", 3, "1.0.0" },
     { "QSTAT", "<queue>", "Return local node queue statistics", 3, "1.0.0" },
     { "QPEEK", "<queue> <count>", "Inspect jobs into a queue without actually fetching them", 3, "1.0.0" },
     { "ENQUEUE", "<jobid> [<jobid> <jobid> ...]", "Force local node to put the specified jobs back into the queue", 3, "1.0.0" },

--- a/src/help.h
+++ b/src/help.h
@@ -46,6 +46,7 @@ struct commandHelp {
     { "WORKING", "<jobid>", "Attempt to postpone next delivery of the specified job", 4, "1.0.0" },
     { "NACK", "<jobid> [<jobid> <jobid> ...]", "Negative acknowledge: increment the NACK counter for the job and ask for a next delivery ASAP", 4, "1.0.0" },
     { "QLEN", "<queue>", "Return number of queued jobs in the specified queue in the local node", 3, "1.0.0" },
+    { "GLOBALQLEN", "<queue>", "Return number of queued jobs in the specified queue across the cluster - it's cached for a minute", 3, "1.0.0" },
     { "QSTAT", "<queue>", "Return local node queue statistics", 3, "1.0.0" },
     { "QPEEK", "<queue> <count>", "Inspect jobs into a queue without actually fetching them", 3, "1.0.0" },
     { "ENQUEUE", "<jobid> [<jobid> <jobid> ...]", "Force local node to put the specified jobs back into the queue", 3, "1.0.0" },

--- a/src/queue.c
+++ b/src/queue.c
@@ -74,6 +74,7 @@ queue *createQueue(robj *name) {
     q->needjobs_adhoc_attempt = 0;
     q->needjobs_responders = NULL; /* Created on demand to save memory. */
     q->clients = NULL; /* Created on demand to save memory. */
+    q->qlenclients = NULL; /* Created on demand to save memory. */
 
     q->current_import_jobs_time = server.mstime;
     q->current_import_jobs_count = 0;
@@ -1302,7 +1303,7 @@ void globalqlenCommand(client *c) {
     }
     
     if (q->last_globalqlen_time>(msnow-GLOBALQLEN_MAX_AGE)
-            && q->globalqlen_nodes == server.cluster->size ) {
+            && (int)q->globalqlen_nodes == server.cluster->size ) {
         addReplyLongLong(c,q->globalqlen);
         return;
     }
@@ -1319,7 +1320,7 @@ void myQLenForQueue(queue *q, uint32_t qlen) {
     if (!q->qlenclients)
         return;
 
-    if (q->globalqlen_nodes == server.cluster->size) {
+    if ((int)q->globalqlen_nodes == server.cluster->size) {
         int numclients = listLength(q->qlenclients);
         while(numclients--) {
             listNode *ln = listFirst(q->qlenclients);

--- a/src/queue.c
+++ b/src/queue.c
@@ -75,6 +75,10 @@ queue *createQueue(robj *name) {
     q->needjobs_responders = NULL; /* Created on demand to save memory. */
     q->clients = NULL; /* Created on demand to save memory. */
     q->qlenclients = NULL; /* Created on demand to save memory. */
+    
+    q->globalqlen = 0;
+    q->last_globalqlen_time = 0;
+    q->globalqlen_nodes = 0;
 
     q->current_import_jobs_time = server.mstime;
     q->current_import_jobs_count = 0;

--- a/src/queue.h
+++ b/src/queue.h
@@ -109,5 +109,6 @@ void receiveYourJobs(struct clusterNode *node, uint32_t numjobs, unsigned char *
 void receiveNeedJobs(struct clusterNode *node, robj *qname, uint32_t count);
 void queueChangePausedState(queue *q, int flag, int set);
 void receivePauseQueue(robj *qname, uint32_t flags);
+void myQLenForQueueName(robj *qname, uint32_t qlen);
 
 #endif

--- a/src/queue.h
+++ b/src/queue.h
@@ -45,6 +45,7 @@ typedef struct queue {
                         queued or when a new client fetches elements or
                         blocks for elements to arrive. */
     list *clients;   /* Clients blocked here. */
+    list *qlenclients;/* Clients waiting for globalqlen. */
 
     /* === Federation related fields === */
     mstime_t needjobs_bcast_time; /* Last NEEDJOBS cluster broadcast. */
@@ -76,6 +77,10 @@ typedef struct queue {
     uint32_t needjobs_bcast_attempt; /* Num of tries without new nodes. */
     uint32_t needjobs_adhoc_attempt; /* Num of tries without new jobs. */
     uint64_t jobs_in, jobs_out;      /* Num of jobs enqueued and dequeued. */
+    mstime_t last_globalqlen_time;   /* time of last globalqlen request. */
+    uint32_t globalqlen;             /* best guess of the globalqlen */
+    uint32_t globalqlen_nodes;       /* nodes who reported myqlen */
+
     uint32_t flags;                  /* Queue flags. QUEUE_FLAG_* macros. */
     uint32_t padding;                /* Not used. Makes alignment obvious. */
 } queue;

--- a/src/server.c
+++ b/src/server.c
@@ -1065,6 +1065,7 @@ void initServerConfig(void) {
     server.assert_line = 0;
     server.bug_report_start = 0;
     server.watchdog_period = 0;
+    server.queue_randomly = 0;
 }
 
 extern char **environ;

--- a/src/server.c
+++ b/src/server.c
@@ -137,6 +137,7 @@ struct serverCommand serverCommandTable[] = {
 
     /* Queues */
     {"qlen",qlenCommand,2,"rF",0,NULL,0,0,0,0,0},
+    {"globalqlen",globalqlenCommand,2,"rF",0,NULL,0,0,0,0,0},
     {"qpeek",qpeekCommand,3,"r",0,NULL,0,0,0,0,0},
     {"qstat",qstatCommand,2,"rF",0,NULL,0,0,0,0,0},
     {"qscan",qscanCommand,-1,"r",0,NULL,0,0,0,0,0},

--- a/src/server.h
+++ b/src/server.h
@@ -201,6 +201,7 @@ typedef long long mstime_t; /* millisecond time type. */
 #define BLOCKED_NONE 0    /* Not blocked, no CLIENT_BLOCKED flag set. */
 #define BLOCKED_JOB_REPL 1 /* Wait job synchronous replication. */
 #define BLOCKED_GETJOB 2   /* Wait for new jobs in a set of queues. */
+#define BLOCKED_GLOBAL_QLEN 3 /* Wait for all the nodes to send MYQLEN */
 
 /* Client request types */
 #define PROTO_REQ_INLINE 1
@@ -854,6 +855,7 @@ void commandCommand(client *c);
 void latencyCommand(client *c);
 void addjobCommand(client *c);
 void qlenCommand(client *c);
+void globalqlenCommand(client *c);
 void getjobCommand(client *c);
 void showCommand(client *c);
 void ackjobCommand(client *c);

--- a/src/server.h
+++ b/src/server.h
@@ -554,6 +554,7 @@ struct disqueServer {
     int assert_line;
     int bug_report_start; /* True if bug report header was already logged. */
     int watchdog_period;  /* Software watchdog period in ms. 0 = off */
+    int queue_randomly;   /* (by default) queue locally or in random node */
 };
 
 typedef void serverCommandProc(client *c);

--- a/tests/cluster/tests/13-globallqlen.tcl
+++ b/tests/cluster/tests/13-globallqlen.tcl
@@ -1,6 +1,11 @@
 source "../tests/includes/init-tests.tcl"
 source "../tests/includes/job-utils.tcl"
 
+test "Globalqlen before anything else" {
+  set gqlen [D 2 globalqlen qlenqueue]
+  assert { $gqlen == 0 }
+}
+
 test "Queue jobs into random nodes" {
   for {set j 1} {$j <= 10} {incr j} {
     set target_id [randomInt $::instances_count]

--- a/tests/cluster/tests/13-globallqlen.tcl
+++ b/tests/cluster/tests/13-globallqlen.tcl
@@ -1,0 +1,38 @@
+source "../tests/includes/init-tests.tcl"
+source "../tests/includes/job-utils.tcl"
+
+test "Queue jobs into random nodes" {
+  for {set j 1} {$j <= 10} {incr j} {
+    set target_id [randomInt $::instances_count]
+    set body "somejob$j"
+    set id [D $target_id addjob qlenqueue $body 5000 replicate 3 retry 60]
+    assert {$id ne {}}
+  }
+}
+
+test "check globalqlen on target node" {
+  set gqlen [D 0 globalqlen qlenqueue]
+  assert {$gqlen == 10}
+}
+
+test "Get jobs from queue" {
+  for {set j 1} {$j <= 10} {incr j} {
+    set target_id [randomInt $::instances_count]
+    set myjob [lindex [D $target_id getjob from qlenqueue] 0]
+    assert {[lindex $myjob 0] eq "qlenqueue"}
+    assert {[lindex $myjob 1] ne {}}
+    assert {[lindex $myjob 2] ne {}}
+
+    set res [D $target_id ackjob [lindex $myjob 1]]
+  }
+}
+
+test "check globalqlen is now empty" {
+  wait_for_condition {
+    [D 1 globalqlen qlenqueue] == 0
+  } else {
+    fail "globalqlen doesn't get empty"
+  }
+}
+
+

--- a/tests/cluster/tests/14-queue-randomly.tcl
+++ b/tests/cluster/tests/14-queue-randomly.tcl
@@ -1,0 +1,27 @@
+source "../tests/includes/init-tests.tcl"
+source "../tests/includes/job-utils.tcl"
+
+set extra_instances [ expr {$::instances_count - 1} ]
+test "we have extra instances" {
+    assert { $extra_instances > 0 }
+}
+
+test "check qlen first" {
+    set qlen [D 0 qlen randomly_queue]
+    assert { $qlen == 0 }
+}
+
+test "Add job with queue-randomly" {
+    set id [D 0 addjob randomly_queue "somejob" 5000 replicate $extra_instances queue-randomly]
+    assert { $id ne {} }
+}
+
+test "qlen is still 0" {
+    set qlen [D 0 qlen randomly_queue]
+    assert { $qlen == 0 }
+}
+
+test "the job is some instance" {
+    set job [D 1 show $id]
+    assert { $job ne {} }
+}


### PR DESCRIPTION
Queue jobs in a random node, instead of the node where they are added.

this is useful for cases where tasks are added in big batches
