### PR TITLE
job.c: Fix timeout calculation until next event

### DIFF
--- a/src/job.c
+++ b/src/job.c
@@ -584,7 +584,7 @@ int processJobs(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     current = server.awakeme->header->level[0].forward;
     if (current) {
         job *j = current->obj;
-        period = server.mstime-j->awakeme;
+        period = j->awakeme - server.mstime;
         if (period < 1) period = 1;
         else if (period > 100) period = 100;
     }


### PR DESCRIPTION
Subtracting the awakeme time from the current time is usually negative, causing the loop to continuously run at 1ms intervals.