### PR TITLE
Eventual replication, including partially async initial confirmations

### DIFF
--- a/src/help.h
+++ b/src/help.h
@@ -39,7 +39,7 @@ struct commandHelp {
     { "QUIT", "-", "Close the connection", 0, "1.0.0" },
     { "LATENCY", "<subcommnad>]", "Latency monitoring", 1, "1.0.0" },
     { "HELLO", "-", "Get list of nodes for clients connection management", 2, "1.0.0" },
-    { "ADDJOB", "<queue> <job> <ms-timeout> [REPLICATE <count>] [DELAY <sec>] [RETRY <sec>] [TTL <sec>] [MAXLEN <count>] [ASYNC]", "Create a new job", 4, "1.0.0" },
+    { "ADDJOB", "<queue> <job> <ms-timeout> [REPLICATE <count>] [DELAY <sec>] [RETRY <sec>] [TTL <sec>] [MAXLEN <count>] [SYNC <count>] [ASYNC]", "Create a new job", 4, "1.0.0" },
     { "GETJOB", "[NOHANG] [TIMEOUT <ms-timeout>] [COUNT <count>] [WITHCOUNTERS] FROM queue1 queue2 ... queueN", "Fetch jobs from queues", 4, "1.0.0" },
     { "ACKJOB", "<jobid> [<jobid> <jobid> ...]", "Acknowledge jobs as delivered", 4, "1.0.0" },
     { "FASTACK", "<jobid> [<jobid> <jobid> ...]", "Acknowledge jobs as delivered deleting the job from the reachable nodes ASAP", 4, "1.0.0" },

--- a/src/job.h
+++ b/src/job.h
@@ -127,6 +127,7 @@ typedef struct job {
                                state is ACKED, this is a list of nodes that
                                confirmed to have the job in acknowledged
                                state. */
+
     /* Note: qtime and awakeme are in milliseconds because we need to
      * desync different nodes in an effective way to avoid useless multiple
      * deliveries when jobs are re-queued. */
@@ -140,6 +141,9 @@ typedef struct job {
                                job in this node. All the registered jobs are
                                ordered by awakeme time in the server.awakeme
                                skip list, unless awakeme is set to zero. */
+
+    uint16_t repl_sync;     /* How many nodes need to confirm replication */ 
+
 } job;
 
 /* Number of bytes of directly serializable fields in the job structure. */
@@ -161,7 +165,8 @@ void updateJobNodes(job *j);
 int registerJob(job *j);
 int unregisterJob(job *j);
 void freeJob(job *j);
-int jobReplicationAchieved(job *j);
+int jobSyncReplicationAchieved(job *j);
+int jobFullReplicationAchieved(job *j);
 job *lookupJob(char *id);
 void updateJobAwakeTime(job *j, mstime_t at);
 void updateJobRequeueTime(job *j, mstime_t qtime);

--- a/tests/cluster/tests/includes/job-utils.tcl
+++ b/tests/cluster/tests/includes/job-utils.tcl
@@ -17,6 +17,22 @@ proc count_job_copies {job {states {queued active}}} {
     return $copies
 }
 
+# Count how many copies of the jobs are found among all nodes
+proc count_job_copies_everywhere {job {states {queued active}}} {
+    set job_id [dict get $job id]
+    set copies 0
+    foreach_disque_id j {
+        if {[instance_is_killed disque $j]} continue
+        set node_id [dict get [get_myself $j] id]
+        set job [D $j show $job_id]
+        if {$job ne {} &&
+            [lsearch -exact $states [dict get $job state]] != -1} {
+             incr copies
+        }
+    }
+    return $copies
+}
+
 # Return the list of instance IDs having a given job in the specified state.
 #
 # If states is an empty string, all the non killed instances not having a copy


### PR DESCRIPTION
NOTE: I am fully aware that the Disque project may be merged into the redis repo
soon as a module of redis 4.2 but I wanted to contribute this idea into disque now
so that this requirement (which is very real for me - your mileage may vary) might
make it into the new & shiny redis module.

First attempt at eventual replication, combining synchronous and asychronous 
replication into one ADDJOB operation.

Developed (hastily) to support a scenario with a 2-node system which is
geographically distributed and must support at-least-once semantics but also
operate each site in 'island mode' where only 1 node may be available for
synchronous replication but when inter-node connectivity is restored the jobs
should be replicated to the other node. In this scenario jobs are added with
REPLICATE 2 SYNC 1 to immediately unblock if the local node is alive but
eventually replicate to the other node if it becomes available.

Adds a SYNC <n> parameter to ADDJOB, which is mutually exclusive with ASYNC.

A job with SYNC <N> specified will perform synchronous (block client)
replication to N nodes. REPLICATE will still control the amount of nodes that
are desired for replication.

When ADDJOB with SYNC <N> is received, REPLJOB messages will be sent to the
amount of nodes controlled by REPLICATE, but the operation will unblock only
when N nodes have confirmed that they have replicated. The rest of the
replication is async, replies will be sent to the origin and they will be added to the confirmed_hosts until full replication has been achieved (sync + async).
The confirmed_hosts dict will be released when full confirmation has been
achieved, which stops any future broadcasts.

This additional replication currently happens in the standard awake timer so
the RETRY parameter in effect controls how often the original node attempts to
gain new replications for this job. This may (more likely will) change in the
future.

NOTE: This patch completely respects that Disque jobs are immutable, thus when
the job unblocks it has been written to the AOF and will not gain knowledge of
additional confirmed nodes later. Only in-memory state will change after that.
The on-the-wire replication protocol and AOF format & logic are unchanged, so
a rolling upgrade to this version should be fine.

Because the confirmed_nodes dict is not serialized to the AOF, any node
restarting will have a NULL dict in which case they will not rebroadcast the
job to additional nodes. Thus if the original node accepting the job is
restarted the message may never reach full replication.

Some test cases have been added to cover the basics of the new functionality.

P.S. I made my first ever PR earlier today and hopefully this one will fare better..